### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "keywords": [
     "ember-addon"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tildeio/ts-std.git"
+  },
   "scripts": {
     "problems": "node ./scripts/problems.js",
     "preversion": "npm run test",


### PR DESCRIPTION
This allows folks to easily find the repo when browsing from npmjs.com or emberobserver.com.